### PR TITLE
Ignore generated CDK output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,8 @@ dist/
 cdk.out/
 .cdk.staging/
 cdk.context.json
+cdk-outputs.json
+**/cdk-outputs.json
 
 # =============================================================================
 # AWS SAM

--- a/web-ui-infrastructure/cdk-outputs.json
+++ b/web-ui-infrastructure/cdk-outputs.json
@@ -1,9 +1,0 @@
-{
-  "X402WebUiStack": {
-    "WebUiUrl": "https://d2r9kngf0syyl.cloudfront.net",
-    "WebUiBucketName": "x402webuistack-webuibucket546eaccb-gti1n9q5pvl9",
-    "WebUiApiEndpoint7C57F56C": "https://y1lb600aql.execute-api.us-west-2.amazonaws.com/prod/",
-    "ApiEndpoint": "https://y1lb600aql.execute-api.us-west-2.amazonaws.com/prod/",
-    "DistributionId": "E3VX04QWZVA9UT"
-  }
-}


### PR DESCRIPTION
This keeps generated CDK deployment outputs out of the sample repository.

Changes:
- remove the committed web-ui-infrastructure/cdk-outputs.json deployment output file
- add cdk-outputs.json patterns to .gitignore so future synth/deploy output is not committed accidentally

Rationale: the sample already ignores CDK build/context artifacts. CDK outputs are local deployment artifacts, so keeping them untracked avoids publishing environment-specific CloudFront/API Gateway/S3 identifiers in the reference sample.

Validation:
- git diff --check